### PR TITLE
Fixed non-existing kvm group. #35

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   tizen:
     privileged: true

--- a/tizen-ide/Dockerfile
+++ b/tizen-ide/Dockerfile
@@ -60,7 +60,11 @@ RUN groupmod -o --gid ${AUDIO_GID} audio \
     && usermod -a -G audio ${TIZEN_USER}
 
 # KVM support
-RUN groupmod -o --gid ${KVM_GID} kvm \
+RUN if [[ $(getent group kvm) ]]; then \
+        groupmod -o --gid ${KVM_GID} kvm; \
+    else \
+        groupadd -g ${KVM_GID} kvm; \
+    fi \
     && usermod -a -G kvm ${TIZEN_USER}
 
 # gnome keyring support


### PR DESCRIPTION
Fixed build error - #35. 
Fixed warning - obsolete 'version' for docker compose.